### PR TITLE
Fix for relative targetEntity classnames in inherited associations

### DIFF
--- a/EventListener/LoadORMMetadataSubscriber.php
+++ b/EventListener/LoadORMMetadataSubscriber.php
@@ -172,6 +172,16 @@ class LoadORMMetadataSubscriber implements EventSubscriber
                                         $mapping['sourceEntity'] = $class;
                                     }
 
+                                    // if target entity is provided by relative classname, make it absolute
+                                    if (!class_exists($mapping['targetEntity']) && strpos($mapping['targetEntity'], '\\') === false) {
+                                        $reflClass = new \ReflectionClass($parentClass);
+                                        $namespace = $reflClass->getNamespaceName();
+                                        $absoluteTargetEntity = $namespace . '\\' . $mapping['targetEntity'];
+                                        if (class_exists($absoluteTargetEntity)) {
+                                            $mapping['targetEntity'] = $absoluteTargetEntity;
+                                        }
+                                    }
+
                                     // add association mapping for actually used class
                                     $metadata->associationMappings[$name] = $mapping;
                                 //}

--- a/Tests/EntityOverride/AssociationExampleTest.php
+++ b/Tests/EntityOverride/AssociationExampleTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Joschi127\DoctrineEntityOverrideBundle\Tests\EntityOverride;
+
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Joschi127\DoctrineEntityOverrideBundle\Tests\Functional\src\Entity\DemoNamespace\BetterAssociationExample;
+use Joschi127\DoctrineEntityOverrideBundle\Tests\Functional\src\Entity\Group;
+use Joschi127\DoctrineEntityOverrideBundle\Tests\TestBase;
+
+class AssociationExampleTest extends TestBase
+{
+    public function testAbsoluteTargetEntityInMetadata()
+    {
+        $repository = $this->em->getRepository(BetterAssociationExample::class);
+        $relfMethod = new \ReflectionMethod($repository, 'getClassMetadata');
+        $relfMethod->setAccessible(true);
+
+        /** @var ClassMetadata $classMetadata */
+        $classMetadata = $relfMethod->invoke($repository);
+
+        self::assertEquals(Group::class, $classMetadata->associationMappings['target']['targetEntity']);
+    }
+
+    public function testAbsoluteTargetEntityInAction()
+    {
+        $group = new Group("AssocTestGroup");
+        $assoc = new BetterAssociationExample();
+        $assoc->setTarget($group);
+
+        $this->em->persist($group);
+        $this->em->persist($assoc);
+        $this->em->flush();
+
+        $this->em->getRepository(BetterAssociationExample::class)->findAll();
+    }
+}

--- a/Tests/Functional/app/config/config.yml
+++ b/Tests/Functional/app/config/config.yml
@@ -82,8 +82,10 @@ joschi127_doctrine_entity_override:
         # OriginalBundle\Entity\Example: CustomizedBundle\Entity\Example
         Joschi127\DoctrineEntityOverrideBundle\Tests\Functional\src\Entity\ExamplePlain: Joschi127\DoctrineEntityOverrideBundle\Tests\Functional\src\Entity\CustomizedExamplePlain
         FOS\UserBundle\Model\User: Joschi127\DoctrineEntityOverrideBundle\Tests\Functional\src\Entity\CustomizedUser
+        Joschi127\DoctrineEntityOverrideBundle\Tests\Functional\src\Entity\AssociationExample: Joschi127\DoctrineEntityOverrideBundle\Tests\Functional\src\Entity\DemoNamespace\BetterAssociationExample
 
 fos_user:
     db_driver: orm
     firewall_name: main
     user_class: Joschi127\DoctrineEntityOverrideBundle\Tests\Functional\src\Entity\CustomizedUser
+    from_email: { sender_name: 'Tester', address: 'test@example.com' }

--- a/Tests/Functional/src/Entity/AssociationExample.php
+++ b/Tests/Functional/src/Entity/AssociationExample.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Joschi127\DoctrineEntityOverrideBundle\Tests\Functional\src\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="namespace_example")
+ */
+class AssociationExample
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    protected $id;
+
+    /**
+     * @ORM\OneToOne(targetEntity="Group")
+     * @ORM\JoinColumn(name="target_id", referencedColumnName="id")
+     */
+    protected $target;
+
+    /**
+     * @return Group
+     */
+    public function getTarget()
+    {
+        return $this->target;
+    }
+
+    /**
+     * @param Group $target
+     */
+    public function setTarget(Group $target)
+    {
+        $this->target = $target;
+    }
+}

--- a/Tests/Functional/src/Entity/DemoNamespace/BetterAssociationExample.php
+++ b/Tests/Functional/src/Entity/DemoNamespace/BetterAssociationExample.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Joschi127\DoctrineEntityOverrideBundle\Tests\Functional\src\Entity\DemoNamespace;
+
+use Joschi127\DoctrineEntityOverrideBundle\Tests\Functional\src\Entity\AssociationExample;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="namespace_example")
+ */
+class BetterAssociationExample extends AssociationExample
+{
+}


### PR DESCRIPTION
There was an issue where if class `Foo\A` has a relation `rel` with target entity `Foo\B`, but this relation target is provided as relative class (i.e. `targetEntity=B`) in the same namespace, but then when `Bar\X extends Foo\A` the relative target is not resolved and results in
```
  [Doctrine\ORM\Mapping\MappingException]                                                   
  The target-entity B cannot be found in 'Bar\X#rel'.
```

This PR aims to resolve this issue by converting relative association targets to absolute ones at copy-time.