### PR TITLE
Add support for Symfony 4

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,9 +4,9 @@ parameters:
 services:
 
     joschi127_doctrine_entity_override.event_subscriber.load_orm_metadata:
-        class: %joschi127_doctrine_entity_override.event_subscriber.load_orm_metadata.class%
+        class: "%joschi127_doctrine_entity_override.event_subscriber.load_orm_metadata.class%"
         arguments:
             - "@service_container"
-            - %joschi127_doctrine_entity_override.config.overridden_entities%
+            - "%joschi127_doctrine_entity_override.config.overridden_entities%"
         tags:
             - { name: doctrine.event_subscriber }

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
   ],
   "require": {
     "php": ">=5.4.5",
-    "symfony/symfony": "~2.8,>=2.8.3|~3.0.6|~3.1",
-    "symfony/framework-bundle": "~2.7,>=2.7.12|~3.0.6|~3.1",
+    "symfony/symfony": "~2.8,>=2.8.3|~3.0.6|~3.1|~4.0",
+    "symfony/framework-bundle": "~2.7,>=2.7.12|~3.0.6|~3.1|~4.0",
     "doctrine/orm": "~2.4,>=2.4.8",
     "doctrine/doctrine-bundle": "~1.6,>=1.6.2"
   },


### PR DESCRIPTION
this avoids deprecation in Symfony 4: 
Not quoting the scalar "..." starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0