### PR TITLE
Full embedded support

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,3 @@
+[user]
+	name = pink
+	email = pink

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,3 +1,0 @@
-[user]
-	name = pink
-	email = pink

--- a/EventListener/LoadORMEmbeddedMetadataSubscriber.php
+++ b/EventListener/LoadORMEmbeddedMetadataSubscriber.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * This file is part of the YAP package
+ *
+ * (c) Sébastien COTON <sebastien.coton@gmail.com>
+ * (c) Ouat's UP
+ * (c) SAS Chaucodel
+ *
+ * L'usage et la diffusion de ce fichier ainsi que de l'ensemble des fichiers
+ * liés au présent projet doit faire l'objet d'un accord express
+ * de l'ensemble des parties citées dans le (c) ci-dessus
+ *
+ */
+
+namespace Joschi127\DoctrineEntityOverrideBundle\EventListener;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class LoadORMEmbeddedMetadataSubscriber implements EventSubscriber {
+
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * @var array
+     */
+    protected $overriddenEntities;
+
+    /**
+     * @var array
+     */
+    protected $parentClassesByClass = [];
+
+    /**
+     * Constructor
+     *
+     * @param array $overriddenEntities
+     */
+    public function __construct(ContainerInterface $container, array $overriddenEntities)
+    {
+        $this->container = $container;
+        $this->overriddenEntities = $overriddenEntities;
+        foreach ($overriddenEntities as $interface => $class) {
+            $class = $this->getClass($class);
+            $this->parentClassesByClass[$class] = array_values(class_parents($class));
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function getSubscribedEvents()
+    {
+        return array(
+            'loadClassMetadata'
+        );
+    }
+
+    /**
+     * @param LoadClassMetadataEventArgs $eventArgs
+     */
+    public function loadClassMetadata(LoadClassMetadataEventArgs $eventArgs)
+    {
+        $em = $eventArgs->getEntityManager();
+
+//        if (false === $eventArgs->getClassMetadata()->isEmbeddedClass)
+//            return ;
+
+        $metadata = $eventArgs->getClassMetadata() ;
+
+        foreach($metadata->embeddedClasses as $propertyName => $embeddedMapping) {
+
+            $overridingClass = $this->getOverridingClass($embeddedMapping['class']);
+
+            if (!$overridingClass)
+                continue ;
+
+            $targetMetadata = $eventArgs->getEntityManager()->getClassMetadata($overridingClass);
+
+            // Removing previous mappings
+
+            foreach($metadata->fieldMappings as $name => $mapping) {
+
+                if (!isset($mapping['declaredField']) || $mapping['declaredField']!=$propertyName)
+                    continue;
+
+                unset($metadata->fieldMappings[$mapping['fieldName']]);
+                unset($metadata->columnNames[$mapping['fieldName']]);
+                unset($metadata->fieldNames[$mapping['columnName']]);
+            }
+
+            // Put the new mappings
+
+            $metadata->inlineEmbeddable($propertyName,$targetMetadata);
+        }
+
+
+    }
+
+
+
+
+    protected function getOverridingClass($className)
+    {
+        foreach ($this->overriddenEntities as $interface => $class) {
+            $interface = $this->getInterface($interface);
+            $class = $this->getClass($class);
+
+            if ($interface === $className) {
+                return $class;
+            }
+
+            foreach($this->parentClassesByClass[$class] as $parentClass) {
+                if ($parentClass === $className) {
+                    return $class;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string           $key
+     *
+     * @return string
+     * @throws \InvalidArgumentException
+     */
+    protected function getInterface($key)
+    {
+        if ($this->container->hasParameter($key)) {
+            return $this->container->getParameter($key);
+        }
+
+        if (interface_exists($key) || class_exists($key)) {
+            return $key;
+        }
+
+        throw new \InvalidArgumentException(
+            sprintf('The interface or class %s does not exists.', $key)
+        );
+    }
+
+    /**
+     * @param string           $key
+     *
+     * @return string
+     * @throws \InvalidArgumentException
+     */
+    protected function getClass($key)
+    {
+        if ($this->container->hasParameter($key)) {
+            return $this->container->getParameter($key);
+        }
+
+        if (class_exists($key)) {
+            return $key;
+        }
+
+        throw new \InvalidArgumentException(
+            sprintf('The class %s does not exists.', $key)
+        );
+    }
+}

--- a/EventListener/LoadORMEmbeddedMetadataSubscriber.php
+++ b/EventListener/LoadORMEmbeddedMetadataSubscriber.php
@@ -1,15 +1,11 @@
 <?php
-/**
- * This file is part of the YAP package
+/*
+ * This file is based on the code of the Sylius ResourceBundle.
  *
- * (c) Sébastien COTON <sebastien.coton@gmail.com>
- * (c) Ouat's UP
- * (c) SAS Chaucodel
+ * (c) Paweł Jędrzejewski
  *
- * L'usage et la diffusion de ce fichier ainsi que de l'ensemble des fichiers
- * liés au présent projet doit faire l'objet d'un accord express
- * de l'ensemble des parties citées dans le (c) ci-dessus
- *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  */
 
 namespace Joschi127\DoctrineEntityOverrideBundle\EventListener;
@@ -96,7 +92,7 @@ class LoadORMEmbeddedMetadataSubscriber implements EventSubscriber {
 
             // Put the new mappings
 
-            $metadata->inlineEmbeddable($propertyName,$targetMetadata);
+            $metadata->inlineEmbeddable($propertyName, $targetMetadata);
         }
 
 

--- a/EventListener/LoadORMMetadataSubscriber.php
+++ b/EventListener/LoadORMMetadataSubscriber.php
@@ -314,8 +314,8 @@ class LoadORMMetadataSubscriber implements EventSubscriber
             // class (but we will keep the declared / inherited flags this time)
             foreach ($metadata->fieldMappings as $name => $mapping) {
 
-                // fields are already declareds
-                if ($this->isEmbeddedProperty($name,$mapping)) {
+                // fields are already declared
+                if ($this->isEmbeddedProperty($name, $mapping)) {
                     unset($metadata->fieldMappings[$mapping['fieldName']]);
                     unset($metadata->columnNames[$mapping['fieldName']]);
                     unset($metadata->fieldNames[$mapping['columnName']]);
@@ -602,7 +602,7 @@ class LoadORMMetadataSubscriber implements EventSubscriber
         );
     }
 
-    public function isEmbeddedProperty($name,$mapping) {
+    public function isEmbeddedProperty($name, $mapping) {
         return isset($mapping['declaredField']);
     }
 }

--- a/README.md
+++ b/README.md
@@ -33,3 +33,24 @@ Hints
   original mapping configuration and only use your customized mapping.
 * Have a look at the [Tests/Functional/src folder](https://github.com/joschi127/doctrine-entity-override-bundle/tree/master/Tests/Functional/src)
   for some example code.
+
+Embedded
+-----
+* rule sould be to initiate the embedded property in the constructor, 
+  but, as we don't know that the embeddable class will be overriden, 
+  it will be responsibility for the developper to use a kind of factory
+  to instantiate the default object property.
+* that is not a problem when the entity is hydrated from database because
+  at this time, Doctrine will take care of it correctly.  
+```
+ /**
+      * @var Adresse
+      * @ORM\Embedded(class="adresse")
+      */
+     protected $adresse;
+ 
+     public function __construct()
+     {
+         $this->adresse = new Adresse();
+     }
+```

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,5 +1,6 @@
 parameters:
     joschi127_doctrine_entity_override.event_subscriber.load_orm_metadata.class: Joschi127\DoctrineEntityOverrideBundle\EventListener\LoadORMMetadataSubscriber
+    joschi127_doctrine_entity_override.event_subscriber.load_embedded_orm_metadata.class: Joschi127\DoctrineEntityOverrideBundle\EventListener\LoadORMEmbeddedMetadataSubscriber
 
 services:
 
@@ -9,4 +10,12 @@ services:
             - "@service_container"
             - "%joschi127_doctrine_entity_override.config.overridden_entities%"
         tags:
-            - { name: doctrine.event_subscriber }
+            - { name: doctrine.event_subscriber, priority: 0 }
+
+    joschi127_doctrine_embedded_entity_override.event_subscriber.load_embedded_orm_metadata:
+        class: "%joschi127_doctrine_entity_override.event_subscriber.load_embedded_orm_metadata.class%"
+        arguments:
+            - "@service_container"
+            - "%joschi127_doctrine_entity_override.config.overridden_entities%"
+        tags:
+            - { name: doctrine.event_subscriber, priority: 2 }

--- a/Tests/EntityOverride/CustomizedUserTest.php
+++ b/Tests/EntityOverride/CustomizedUserTest.php
@@ -5,6 +5,7 @@ namespace Joschi127\DoctrineEntityOverrideBundle\Tests\EntityOverride;
 use Doctrine\ORM\EntityRepository;
 use FOS\UserBundle\Doctrine\UserManager;
 use Joschi127\DoctrineEntityOverrideBundle\Tests\Functional\src\Entity\CustomizedUser;
+use Joschi127\DoctrineEntityOverrideBundle\Tests\Functional\src\Entity\EmbeddedAddressV2;
 use Joschi127\DoctrineEntityOverrideBundle\Tests\Functional\src\Entity\Group;
 use Joschi127\DoctrineEntityOverrideBundle\Tests\Functional\src\Entity\UserActivity;
 use Joschi127\DoctrineEntityOverrideBundle\Tests\TestBase;
@@ -183,12 +184,19 @@ class CustomizedUserTest extends TestBase
             'Joschi127\DoctrineEntityOverrideBundle\Tests\Functional\src\Entity\CustomizedUser',
             $user
         );
+
         $cleanUser = $this->getNewTestUserObject();
         $this->assertEquals($this->getTestUsername(), $user->getUsername());
         $this->assertEquals($cleanUser->getFirstName(), $user->getFirstName());
         $this->assertEquals($cleanUser->getLastName(), $user->getLastName());
         $this->assertEquals($cleanUser->getEmail(), $user->getEmail());
         $this->assertEquals($cleanUser->getPhoneNumber(), $user->getPhoneNumber());
+
+
+        $this->assertInstanceOf(
+            EmbeddedAddressV2::class,
+            $user->getAdresse()
+        );
     }
 
     protected function createUser()

--- a/Tests/Functional/app/config/config.yml
+++ b/Tests/Functional/app/config/config.yml
@@ -83,6 +83,7 @@ joschi127_doctrine_entity_override:
         Joschi127\DoctrineEntityOverrideBundle\Tests\Functional\src\Entity\ExamplePlain: Joschi127\DoctrineEntityOverrideBundle\Tests\Functional\src\Entity\CustomizedExamplePlain
         FOS\UserBundle\Model\User: Joschi127\DoctrineEntityOverrideBundle\Tests\Functional\src\Entity\CustomizedUser
         Joschi127\DoctrineEntityOverrideBundle\Tests\Functional\src\Entity\AssociationExample: Joschi127\DoctrineEntityOverrideBundle\Tests\Functional\src\Entity\DemoNamespace\BetterAssociationExample
+        Joschi127\DoctrineEntityOverrideBundle\Tests\Functional\src\Entity\EmbeddedAdress: Joschi127\DoctrineEntityOverrideBundle\Tests\Functional\src\Entity\EmbeddedAdressV2
 
 fos_user:
     db_driver: orm

--- a/Tests/Functional/src/Entity/EmbeddedAddress.php
+++ b/Tests/Functional/src/Entity/EmbeddedAddress.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Joschi127\DoctrineEntityOverrideBundle\Tests\Functional\src\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Class EmbeddedAddress
+ * @package Joschi127\DoctrineEntityOverrideBundle\Tests\Functional\src\Entity
+ *
+ * @ORM\Embeddable()
+ */
+class EmbeddedAddress {
+    /**
+     * @var string|null
+     * @ORM\Column(type="string",nullable=true)
+     */
+    protected $city;
+
+    /**
+     * @return string|null
+     */
+    public function getCity()
+    {
+        return $this->city;
+    }
+
+    /**
+     * @param string|null $city
+     */
+    public function setCity(?string $city)
+    {
+        $this->city = $city;
+        return $this;
+    }
+
+
+}

--- a/Tests/Functional/src/Entity/EmbeddedAddressV2.php
+++ b/Tests/Functional/src/Entity/EmbeddedAddressV2.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Joschi127\DoctrineEntityOverrideBundle\Tests\Functional\src\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Class EmbeddedAddressV2
+ * @package Joschi127\DoctrineEntityOverrideBundle\Tests\Functional\src\Entity
+ *
+ * @ORM\Embeddable()
+ */
+class EmbeddedAddressV2 extends EmbeddedAddress {
+    /**
+     * @var string|null
+     * @ORM\Column(type="string",nullable=true)
+     */
+    protected $zip;
+
+    /**
+     * @return string|null
+     */
+    public function getZip()
+    {
+        return $this->zip;
+    }
+
+    /**
+     * @param string|null $zip
+     */
+    public function setZip(?string $zip)
+    {
+        $this->zip = $zip;
+        return $this;
+    }
+
+
+
+
+}

--- a/Tests/Functional/src/Entity/User.php
+++ b/Tests/Functional/src/Entity/User.php
@@ -2,6 +2,7 @@
 
 namespace Joschi127\DoctrineEntityOverrideBundle\Tests\Functional\src\Entity;
 
+use App\Entity\Adresse2;
 use FOS\UserBundle\Model\User as BaseUser;
 
 use Doctrine\Common\Collections\ArrayCollection;
@@ -66,11 +67,20 @@ class User extends BaseUser
      */
     protected $userActivity;
 
+    /**
+     * @var Adresse
+     * @ORM\Embedded(class="adresse")
+     */
+    protected $adresse;
+
     public function __construct()
     {
         parent::__construct();
 
         $this->groups = new ArrayCollection();
+
+
+
     }
 
     /**
@@ -122,4 +132,23 @@ class User extends BaseUser
 
         $this->userActivity = $userActivity;
     }
+
+    /**
+     * @return Adresse
+     */
+    public function getAdresse()
+    {
+        return $this->adresse;
+    }
+
+    /**
+     * @param Adresse $adresse
+     */
+    public function setAdresse(Adresse $adresse)
+    {
+        $this->adresse = $adresse;
+        return $this;
+    }
+
+
 }


### PR DESCRIPTION
Here is a first try to overrided embedded property class in the same way as for entities.

In addition to previous PR about light embedded support :
- i had create another listener with a higher priority

The purpose of this listener is to replace the mappings of fields related to embedded properties.

I had take the assumption that properties of an embeddable class are "simple" and won't be overloaded in the child class.
