### PR TITLE
Fix dependencies to use symfony flex

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,16 +13,16 @@
   ],
   "require": {
     "php": ">=5.6.0",
-    "symfony/symfony": "~2.8,>=2.8.3|~3.0.6|~3.1|~4.0",
-    "symfony/framework-bundle": "~2.7,>=2.7.12|~3.0.6|~3.1|~4.0",
-    "doctrine/orm": "~2.4,>=2.4.8",
-    "doctrine/doctrine-bundle": "~1.6,>=1.6.2"
+    "symfony/framework-bundle": "^2.7.12|^3.0.6|^4.0",
+    "doctrine/orm": "^2.4.8",
+    "doctrine/doctrine-bundle": "^1.6.2"
   },
   "require-dev": {
     "phpunit/phpunit": "5.7.*",
-    "symfony/monolog-bundle": "~2.4",
-    "symfony/swiftmailer-bundle": "~2.3",
-    "friendsofsymfony/user-bundle": "dev-master"
+    "symfony/finder": "^2.4|^3.0|^4.0",
+    "symfony/monolog-bundle": "^2.4|^3.0|^4.0",
+    "symfony/swiftmailer-bundle": "^2.3|^3.0",
+    "friendsofsymfony/user-bundle": "^2.1"
   },
   "autoload": {
     "psr-4": { "Joschi127\\DoctrineEntityOverrideBundle\\": "" }


### PR DESCRIPTION
Symfony Flex doesn't work with `symfony/symfony` dependency: withhttps://symfony.com/doc/current/setup/flex.html#upgrading-existing-applications-to-flex